### PR TITLE
Update composer.json to allow SF8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
     "require": {
         "php": ">=8.2",
         "php-flasher/flasher": "^2.2.0",
-        "symfony/config": "^7.0",
-        "symfony/console": "^7.0",
-        "symfony/dependency-injection": "^7.0",
-        "symfony/http-kernel": "^7.0"
+        "symfony/config": "^7.0 || ^8.0",
+        "symfony/console": "^7.0 || ^8.0",
+        "symfony/dependency-injection": "^7.0 || ^8.0",
+        "symfony/http-kernel": "^7.0 || ^8.0"
     },
     "suggest": {
         "symfony/translation": "To translate flash messages, title and presets",


### PR DESCRIPTION
I've read the fact that we have to PR the base repo but it's already updated for SF8 but not this one inspite of the fact it's the way the install it in SF.
So i think this repo is the good place to be.
Tell me if not finally.
Damien